### PR TITLE
Parameter verification for Pong and RaycastMaze

### DIFF
--- a/ple/games/pong.py
+++ b/ple/games/pong.py
@@ -196,6 +196,13 @@ class Pong(PyGameWrapper):
 
     def __init__(self, width=64, height=48, cpu_speed_ratio=0.6, players_speed_ratio = 0.4, ball_speed_ratio=0.75,  MAX_SCORE=11):
 
+        assert width > 0, "Error: width must be greater than 0"
+        assert height > 0, "Error: height must be greater than 0"
+        assert cpu_speed_ratio > 0, "Error: cpu_speed_ratio must be greater than 0"
+        assert players_speed_ratio > 0, "Error: player_speed_ratio must be greater than 0"
+        assert ball_speed_ratio > 0, "Error: ball_speed_ration must be greater than 0"
+        assert MAX_SCORE > 0, "Error: MAX_SCORE must be greater than 0"
+
         actions = {
             "up": K_w,
             "down": K_s

--- a/ple/games/raycastmaze.py
+++ b/ple/games/raycastmaze.py
@@ -43,7 +43,15 @@ class RaycastMaze(PyGameWrapper, RayCastPlayer):
                  move_speed=20, turn_speed=13,
                  map_size=10, height=48, width=48, init_pos_distance_to_target=None):
 
-        assert map_size > 5, "map_size must be gte 5"
+        for x in init_pos:
+            assert (x >= 0) and (x < map_size), "Error: init_pos must be on the map (0 to map_size)"
+        assert resolution > 0, "Error: resolution must be greater than 0"
+        assert move_speed > 0, "Error: move_speed must be greater than 0"
+        assert move_speed < 100, "Error: move_speed must be less than 100"
+        assert turn_speed > 0, "Error: turn_speed must be greater than 0"
+        assert turn_speed < 100, "Error: turn_speed must be less than 100"
+        assert (map_size > 5) and (map_size <= 100), "Error: map_size must be >= 5 and <= 100"
+        assert (height > 0) and (width > 0) and (height == width), "Error: height and width must be equal and greater than 0"
 
         # do not change
         init_dir = (1.0, 0.0)

--- a/tests/test_pong.py
+++ b/tests/test_pong.py
@@ -59,11 +59,15 @@ def test_invalid_max_score():
     with pytest.raises(Exception):
         game=Pong(MAX_SCORE=-1)
 
-def test_invalid_action_input():
-    game=Pong()
-    p=PLE(game, display_screen=True, fps=20, force_fps=1)
-    p.init()
-    time.sleep(.5)
-    with pytest.raises(Exception):
-        p.act(10)
+#I'm commenting out this test currently because it is unclear whether the game should 
+#       throw an exception for an undefinied action, or do nothing (basically a wait step)
+#       Refer to ple.py lines 361-367 in the definition of act(int) for this
+#
+#def test_invalid_action_input():
+#    game=Pong()
+#    p=PLE(game, display_screen=True, fps=20, force_fps=1)
+#    p.init()
+#    time.sleep(.5)
+#    with pytest.raises(Exception):
+#        p.act(10)
 


### PR DESCRIPTION
This PR implements a solution to issue #2 .

pong.py and raycastmaze.py now properly assert reasonable values for the parameters, like width and height > 0 and non-negative speeds for player and cpu controlled objects.

Additionally, I commented out a test I had previously written for pong.py that asked for an exception if an invalid action was taken by the user agent. Upon further investigation I'm unsure if this would be intended behavior, so I have removed the test for now.